### PR TITLE
Change npm's default directory to avoid permission issues

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -43,6 +43,9 @@ export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 # Yarn
 export PATH=$HOME/.yarn/bin:$PATH
 
+# Npm
+export PATH=~/.npm-global/bin:$PATH
+
 ## History command configuration
 HISTSIZE=5000                 # How many lines of history to keep in memory
 HISTFILE=~/.zsh_history       # Where to save history to disk

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ sudo usermod -aG docker $USER
 
 # Create .screen folder used by .zshrc
 mkdir ~/.screen && chmod 700 ~/.screen
+
+# Change npm's default directory
+mkdir ~/.npm-global
+npm config set prefix '~/.npm-global'
 ```
 
 #### Restore (or generate) the GPG key


### PR DESCRIPTION
Changement du répertoire par défaut d'installation des dépendances globales de nom.

Cette PR suis la méthode décrite dans cet article : http://npm.github.io/installation-setup-docs/installing/a-note-on-permissions.html

Dans le cas ou le répertoire global n'est pas redéfini, des erreurs de type EACCES sont générées à l'installation d'un package global.